### PR TITLE
feat: add stop and movePolar methods for Mecanum drive

### DIFF
--- a/arduino/robot/mecunum.cpp
+++ b/arduino/robot/mecunum.cpp
@@ -29,6 +29,18 @@ void mec::Mecanum::move(float vx, float vy, float w){
     
 }
 
+void mec::Mecanum::stop() {
+    for (int i = 0; i < 4; ++i) {
+        _motor(motorPins[i].RPWM_OUTPUT, motorPins[i].LPWM_OUTPUT, 0);
+    }
+}
+
+void mec::Mecanum::movePolar(float speed, float angle, float w) {
+    float vx = speed * cos(angle);
+    float vy = speed * sin(angle);
+    move(vx, vy, w);
+}
+
 void mec::Mecanum::_motor(int pinR, int pinL, int speed) {
 
     int pwm = constrain(abs(speed), 0, 255);
@@ -51,14 +63,14 @@ void mec::Mecanum::_computeMecanumParam(float vx, float vy, float w, int *motor_
     float min_motor_w = -max_motor_w;
     
     float tmp_motor_w[4] = {0};
-    tmp_motor_w[0] = (vx - vy - length_x_y*w )/Mecanum_Wheel_Radius;
-    tmp_motor_w[1] = (vx + vy + length_x_y*w )/Mecanum_Wheel_Radius;
-    tmp_motor_w[2] = (vx + vy - length_x_y*w )/Mecanum_Wheel_Radius;
-    tmp_motor_w[3] = (vx - vy + length_x_y*w )/Mecanum_Wheel_Radius;
+    tmp_motor_w[0] = ( vx - vy - length_x_y*w )/Mecanum_Wheel_Radius;
+    tmp_motor_w[1] = ( vx + vy + length_x_y*w )/Mecanum_Wheel_Radius;
+    tmp_motor_w[2] = ( vx + vy - length_x_y*w )/Mecanum_Wheel_Radius;
+    tmp_motor_w[3] = ( vx - vy + length_x_y*w )/Mecanum_Wheel_Radius;
 
     // normalize
     for(int i = 0; i< 4; ++i){
-        float tmp_w = (tmp_motor_w[i] - min_motor_w) / ( max_motor_w - min_motor_w);
+        float tmp_w = (tmp_motor_w[i] - min_motor_w) / (max_motor_w - min_motor_w);
         motor_pwm[i] = (tmp_w - 0.5) * 255;
 
         motor_pwm[i] = motor_pwm[i] > 255? 255: motor_pwm[i];

--- a/arduino/robot/mecunum.h
+++ b/arduino/robot/mecunum.h
@@ -34,7 +34,8 @@ namespace mec{
                     Mecanum();
                     ~Mecanum();
                     void move(float vx, float vy, float w);
-                    
+                    void stop();
+                    void movePolar(float speed, float angle, float w = 0);
                     
             private:
                     void _motor(int pinR, int pinL, int speed);

--- a/arduino/robot/robot.ino
+++ b/arduino/robot/robot.ino
@@ -7,7 +7,6 @@ void setup() {
 }
 
 void loop() {
-    mecanum.move(1 , 0, 0);
+    mecanum.move(1, 0, 0);
     delay(10);
-
 }


### PR DESCRIPTION
Added a stop function to stop the robot's movement, and a movePolar function that takes speed and angle (in polar coordinates) as input.
Note: The x-axis points forward relative to the robot, and the y-axis points to the robot's left side.