### PR TITLE
feat: remove baud rate argument in serialCommunicate

### DIFF
--- a/arduino/robot/SerialCommunicate.cpp
+++ b/arduino/robot/SerialCommunicate.cpp
@@ -129,20 +129,24 @@ size_t cmd::CommandProtocol::_expectPacketSize(cmd::Command_Type inputCommand){
 	return expectSize;
 }
 
-SerialCommunicate::SerialCommunicate(HardwareSerial *serial, int baud):_serial(serial){
-	
+SerialCommunicate::SerialCommunicate(HardwareSerial *serial):_serial(serial){
 }
 
 SerialCommunicate::~SerialCommunicate(){
+}
+
+void SerialCommunicate::init(){
+	_serial->begin(115200);
+	_serial->flush();
 }
 
 cmd::Command_Type SerialCommunicate::read(vector<uint8_t> &outputData){
 	
 	cmd::Command_Type returnCMD = cmd::Command_Type::None;
 
-	while(Serial.available()){
+	while(_serial->available()){
 		
-		char c = Serial.read();
+		char c = _serial->read();
 
 		_packet.push_back(c);
 		
@@ -171,7 +175,7 @@ void SerialCommunicate::write(const vector<uint8_t> &inputData, cmd::Command_Typ
 	vector<uint8_t> outputPacket;
 	buildPacket(inputCommand, inputData, outputPacket);
 
-	Serial.write(outputPacket.begin(), outputPacket.size());
+	_serial->write(outputPacket.begin(), outputPacket.size());
 }
 
 bool SerialCommunicate::_startFlag(){

--- a/arduino/robot/SerialCommunicate.h
+++ b/arduino/robot/SerialCommunicate.h
@@ -55,8 +55,9 @@ class CommandProtocol{
 
 class SerialCommunicate: private cmd::CommandProtocol{
 	public:
-		SerialCommunicate(HardwareSerial *serial, int baud = 115200);
+		SerialCommunicate(HardwareSerial *serial);
 		~SerialCommunicate();
+		void init();
 		cmd::Command_Type read(vector<uint8_t> &outputData);
 		void write(const vector<uint8_t> &inputData, cmd::Command_Type inputCommand);
 		

--- a/arduino/robot/robot.ino
+++ b/arduino/robot/robot.ino
@@ -17,7 +17,6 @@ float angle = 0.0;
 float w = 0.0;
 
 void setup() {
-	Serial.begin(115200);
 	imu.init(&mpu);
 	pinMode(13, OUTPUT);
 	digitalWrite(13, LED_BLINK_STATE);


### PR DESCRIPTION
fix the problem that pass serial cannot work normally.

remove the baud rate argument of SerialCommunicate class.

i guess if this serial.begin(baud) is not a definite value will cause the Serial communication parse data incorrectly